### PR TITLE
Harden PostgresSQL blueprint

### DIFF
--- a/kanister-postgresql/kanister/postgres-blueprint.yaml
+++ b/kanister-postgresql/kanister/postgres-blueprint.yaml
@@ -46,7 +46,9 @@ actions:
           cat << EOF > "${recover_dir}"/recovery.conf
           restore_command = 'wal-e wal-fetch "%f" "%p"'
           recovery_target_action = 'shutdown'
+          recovery_end_command = 'rm -fr $PGDATA/recovery.conf'
           EOF
+          sync
     - func: KubeTask
       name: restartPod
       args:
@@ -57,6 +59,26 @@ actions:
         - errexit
         - -o
         - pipefail
+        - -o
+        - xtrace
         - -c
         - |
-          kubectl delete --namespace "{{ .Deployment.Namespace }}" pod "{{ index .Deployment.Pods 0 }}"
+          # Recreate (scale down and up) the pod so it can be recreated forcing init containers
+          # to run again. One of the init containers will move the restored files to the
+          # correct data location.
+          # Need to wait for terminating pod instance to complete before
+          # scaling back up to avoid writing to the same volume from the PG shutdown sequence
+          # in the terminating pod and the restore completion init container simultaneously.
+          #
+          # TODO: Should have a kanister function to abstract the termination sync
+          # or should incorporate in any function that replaces data files under the
+          # application
+          namespace="{{ .Deployment.Namespace }}"
+          deployment="{{ .Deployment.Name }}"
+          pod="{{ index .Deployment.Pods 0 }}"
+          kubectl scale --namespace $namespace deployment $deployment --replicas=0
+          while [ ! -z "$(kubectl -n $namespace get pod | grep $pod | grep Terminating)" ]
+          do
+            sleep 1
+          done
+          kubectl scale --namespace $namespace deployment $deployment --replicas=1

--- a/kanister-postgresql/templates/deployment.yaml
+++ b/kanister-postgresql/templates/deployment.yaml
@@ -51,6 +51,7 @@ spec:
             then
                 # Recovery in progress. Finalizing replacing files
                 # Replace files from the relevant full backup
+                #
                 # TODO: Currently .conf files unchanged. Include in backup in future
                 ls -d ${PGDATA}/kanister-restore/* | sed 's/kanister-restore\///' | xargs -t rm -fr
                 mv ${PGDATA}/kanister-restore/* ${PGDATA}/.
@@ -62,10 +63,8 @@ spec:
                 cat ${PGDATA}/recovery.conf
                 PG_CTL="$(which pg_ctl)"
                 su - postgres --preserve-environment -c "${PG_CTL} -D ${PGDATA} -w start -t 36000"
-                # Regardless of how we get here, complete recovery
-                # Needed if the recovery is interrupted because of incomplete WAL set (for latest)
-                # TODO: Once specific PIT recovery is supported this can be simplified
-                mv ${PGDATA}/recovery.conf ${PGDATA}/recovery.done_kanister || true
+                # Should have recovered to recovery.conf settings. Current version instructs
+                # postgress to shutdown when recovery is complete
             fi
           env:
           - name: POSTGRES_USER


### PR DESCRIPTION
 * Make sure recovery.conf is persisted on disk before pod restart

 * Before replacing data on restore make sure the restarting pod
   has completed terminating to avoid simultaneous writes to PGDATA

   Scale the deployment down/up instead of terminating pods to
   avoid the replication controller from kicking in before the
   old pod is no longer accessing the volume